### PR TITLE
VE-1463: Encode endpoint URI

### DIFF
--- a/lib/mediawiki.ApiRequest.js
+++ b/lib/mediawiki.ApiRequest.js
@@ -596,7 +596,7 @@ function ParsoidCacheRequest ( env, title, oldid, options ) {
 		oldid: oldid
 	};
 	var uri = env.conf.parsoid.parsoidCacheURI +
-			encodeURIComponent( env.conf.wiki.iwp ) + '/' + encodeURIComponent(title.replace(/ /g, '_')) +
+			encodeURIComponent(env.conf.wiki.iwp) + '/' + encodeURIComponent(title.replace(/ /g, '_')) +
 			'?' + qs.stringify( apiargs );
 	this.uri = uri;
 


### PR DESCRIPTION
Unlike WMF we pass to Parsoid not a symbolic name pointing to a wiki, but entire URL to api.php. That URL has to be encoded, and currently we were doing it properly in MediaWiki but not in Parsoid itself (in case when Parsoid calls Parsoid :)).
