### PR TITLE
VE-2053: Do not expect parameters to be present when parsing template directly

### DIFF
--- a/lib/ext.Infobox.js
+++ b/lib/ext.Infobox.js
@@ -24,7 +24,7 @@ Infobox.prototype.handleInfobox = function(manager, pipelineOpts, token, cb) {
 	// templateArgInfo is set in TemplateHandler.onTemplate
 	var arg,
 		infoboxArgInfo = manager.frame.parentFrame.templateArgInfo[manager.frame.title].shift(),
-		args = infoboxArgInfo.dict.params;
+		args = infoboxArgInfo ? infoboxArgInfo.dict.params : {};
 
 	for (arg in args) {
 		args[arg] = args[arg].wt;


### PR DESCRIPTION
When parsing template (which contains portable infobox) directly then params are not set - because there is no invocation - so do not expect them to be set, ok?