### PR TITLE
Backporting VE-2114 for earlier release

### DIFF
--- a/lib/dom.t.unpackDOMFragments.js
+++ b/lib/dom.t.unpackDOMFragments.js
@@ -193,8 +193,10 @@ function unpackDOMFragments(env, node) {
 
 			// Transfer mw:Transclusion typeof
 			if (/(?:^|\s)mw:Transclusion(?=$|\s)/.test(typeOf)) {
+				// Transfer typeof, data-mw, and param info 
 				DU.setDataMw(contentNode, Util.clone(DU.getDataMw(node)));
 				DU.addTypeOf(contentNode, "mw:Transclusion");
+				DU.getDataParsoid(contentNode).pi = dp.pi;
 			}
 
 			// Update DSR:


### PR DESCRIPTION
See:
https://wikia-inc.atlassian.net/browse/VE-2114
https://wikia-inc.atlassian.net/browse/DAT-3594

VE-2114: Carry over PI (paramInfo) when unpacking DOMFragment
ParamInfo is needed in order to properly preserve template parameters formatting when serializing htmldom to wt (after the edit).