### PR TITLE
OPS-4810: Get Parsoid to stop properly on ctrl+c or SIGINT by porting changes from upstream

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -9,7 +9,8 @@ var path = require('path'),
 	cluster = require('cluster'),
 	domino = require('domino'),
 	pkg = require('../package.json'),
-	apiUtils = require('./utils');
+	apiUtils = require('./utils'),
+	semver = require('semver');
 
 
 // relative includes
@@ -75,7 +76,7 @@ var makeDone = function( reqId ) {
 };
 
 // Cluster support was very experimental and missing methods in v0.8.x
-var sufficientNodeVersion = !/^v0\.[0-8]\./.test( process.version );
+var sufficientNodeVersion = semver.gte(process.version, '0.10.0');
 
 var cpuTimeout = function( p, res ) {
 	var reqId = res.local("reqId");

--- a/lib/utils/promise.js
+++ b/lib/utils/promise.js
@@ -1,0 +1,1 @@
+module.exports = require('prfun/wrap')(require('babybird'));

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"dependencies": {
 		"alea": "~0.0.9",
 		"async": "~0.9.0",
+		"babybird": "^0.0.1",
 		"bunyan": "~1.0.0",
 		"diff": "~1.0.7",
 		"domino": "~1.0.18",
@@ -19,6 +20,7 @@
 		"pegjs": "git+https://github.com/arlolra/pegjs#startOffset",
 		"prfun": "~1.0.2",
 		"request": "~2.40.0",
+		"semver": "^5.1.0",
 		"simplediff": "~0.1.1",
 		"yargs": "~1.3.1",
 		"newrelic": "~1.5.4"


### PR DESCRIPTION
While working on this I discovered that original upstream changes (very fresh) were not correct - Parsoid still wasn't stopping properly on ctrl+c - this is because ctrl+c sends SIGINT not only to parent process but also to all foreground processes. I worked with Arlolra from WMF and now this is fixed.