### PR TITLE
VE-2127: Port of "Use compression package instead of the older version in connect"

### DIFF
--- a/api/ParsoidService.js
+++ b/api/ParsoidService.js
@@ -7,6 +7,7 @@ require('../lib/core-upgrade.js');
 
 // global includes
 var express = require('express'),
+	compression = require('compression'),
 	hbs = require('handlebars'),
 	cluster = require('cluster'),
 	path = require('path'),
@@ -42,7 +43,7 @@ function ParsoidService( parsoidConfig, processLogger ) {
 	app.use(express.bodyParser({ maxFieldsSize: 15 * 1024 * 1024 }));
 
 	// Support gzip / deflate transfer-encoding
-	app.use(express.compress());
+	app.use(compression());
 
 	// limit upload file size
 	app.use(express.limit('15mb'));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"entities": "~1.1.1",
 		"es6-shim": "~0.16.0",
 		"express": "~2.5.11",
+		"compression": "~1.4.0",
 		"gelf-stream": "~0.2.4",
 		"handlebars": "~1.3.0",
 		"html5": "~1.0.5",


### PR DESCRIPTION
https://github.com/wikimedia/parsoid/commit/26ec08ff1cc5f6d9e4cd77475c950603dc7c941b