### PR TITLE
Tune Kubernetes update strategy

### DIFF
--- a/k8s/metric.yaml
+++ b/k8s/metric.yaml
@@ -26,6 +26,11 @@ spec:
     matchLabels:
       app: parsoid-metric-feeder
   replicas: ${replicas}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 2
   template:
     metadata:
       labels:
@@ -49,10 +54,12 @@ spec:
           httpGet:
             path: /
             port: 8000
+          initialDelaySeconds: 12
         readinessProbe:
           httpGet:
             path: /
             port: 8000
+          initialDelaySeconds: 5
         ports:
         - containerPort: 8000
 

--- a/k8s/parsoid.yaml
+++ b/k8s/parsoid.yaml
@@ -26,6 +26,11 @@ spec:
     matchLabels:
       app: parsoid
   replicas: ${replicas}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 2
   template:
     metadata:
       labels:
@@ -49,10 +54,12 @@ spec:
           httpGet:
             path: /
             port: 8000
+          initialDelaySeconds: 12
         readinessProbe:
           httpGet:
             path: /
             port: 8000
+          initialDelaySeconds: 5
         ports:
         - containerPort: 8000
 


### PR DESCRIPTION
Ensure that newly deployed version of application passes health checks, before destroying old pods
* use `RollingUpdate` strategy with surge
* configure `readinessProbe`