### PR TITLE
Parsoid - log cache hit/miss properly

### DIFF
--- a/lib/mediawiki.ApiRequest.js
+++ b/lib/mediawiki.ApiRequest.js
@@ -179,7 +179,7 @@ ApiRequest.prototype._requestCB = function (error, response, body) {
 	} else if (response.statusCode === 200) {
 		this._handleBody( null, body );
 	} else {
-		if (response.statusCode === 412) {
+		if (response.statusCode === 412 || response.statusCode === 504) {
 			this.env.log("info", "Cache MISS:", this.uri);
 		} else {
 			this.env.log("warning", "non-200 response:", response.statusCode, body);
@@ -680,6 +680,8 @@ ParsoidCacheRequest.prototype._handleBody = function ( error, body ) {
 		this._processListeners( error, '' );
 		return;
 	}
+
+	this.env.log('info', 'Cache hit:', this.uri);
 
 	//console.log( this.listeners('parsedHtml') );
 	this._processListeners( error, body );


### PR DESCRIPTION
Also do not vomit raw HTML to stdout when varnish returns 504 Entity Not In Cache