### PR TITLE
Update request to 2.86.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"html5": "~1.0.5",
 		"pegjs": "git+https://github.com/arlolra/pegjs#startOffset",
 		"prfun": "~1.0.2",
-		"request": "^2.83.0",
+		"request": "^2.86.0",
 		"semver": "^5.1.0",
 		"serve-favicon": "^2.4.5",
 		"simplediff": "~0.1.1",


### PR DESCRIPTION
Fixes https://snyk.io/vuln/npm:stringstream:20180511 - the vulnerability does not affect us, but we get rid of the security notification this way.