### PR TITLE
Set proper user agent string for metric processor Parsoids

### DIFF
--- a/api/localsettings.js
+++ b/api/localsettings.js
@@ -13,10 +13,5 @@ exports.setup = function( parsoidConfig ) {
 			parsoidConfig.parsoidCacheProxy = `http://${envName}.icache.service.consul:80/`;
 			parsoidConfig.defaultAPIProxyURI = `http://${envName}.icache.service.consul:80/`;
 		}
-
-		// Set a proper user agent for metric processor Parsoids
-		if (process.env.USER_AGENT) {
-			parsoidConfig.userAgent = process.env.USER_AGENT;
-		}
 	}
 };

--- a/api/localsettings.js
+++ b/api/localsettings.js
@@ -1,11 +1,6 @@
-/*
- * This is a sample configuration file.
- *
- * Copy this file to localsettings.js and edit that file to fit your needs.
- *
- * Also see the file ParserService.js for more information.
+/**
+ * I am the configuration file
  */
-
 exports.setup = function( parsoidConfig ) {
 	parsoidConfig.useSelser = true;
 	parsoidConfig.maxRequestsPerChild = 100;
@@ -17,6 +12,11 @@ exports.setup = function( parsoidConfig ) {
 			parsoidConfig.parsoidCacheURI = `http://${envName}.parsoid-cache/`;
 			parsoidConfig.parsoidCacheProxy = `http://${envName}.icache.service.consul:80/`;
 			parsoidConfig.defaultAPIProxyURI = `http://${envName}.icache.service.consul:80/`;
+		}
+
+		// Set a proper user agent for metric processor Parsoids
+		if (process.env.USER_AGENT) {
+			parsoidConfig.userAgent = process.env.USER_AGENT;
 		}
 	}
 };

--- a/k8s/metric.yaml
+++ b/k8s/metric.yaml
@@ -45,6 +45,8 @@ spec:
         env:
         - name: ENV
           value: ${ns}
+        - name: USER_AGENT
+          value: ParsoidMetric/4.20
         resources:
           limits:
             memory: 3Gi

--- a/lib/mediawiki.ApiRequest.js
+++ b/lib/mediawiki.ApiRequest.js
@@ -10,6 +10,8 @@ var Agent = require('./_http_agent.js').Agent,
 	});
 require('http').globalAgent = httpAgent;
 
+var parsoidConfig = require('./mediawiki.ParsoidConfig');
+
 var request = require('request'),
 	qs = require('querystring'),
 	events = require('events'),
@@ -20,7 +22,8 @@ var request = require('request'),
 // all revision properties which parsoid is interested in.
 var PARSOID_RVPROP = ('content|ids|timestamp|user|userid|size|sha1|contentmodel|comment');
 
-var userAgent = 'Parsoid/0.1';
+// Wikia change - set proper user agent for metric processor Parsoids
+var userAgent = parsoidConfig.userAgent ? parsoidConfig.userAgent : 'Parsoid/0.1';
 
 /**
  * @class

--- a/lib/mediawiki.ApiRequest.js
+++ b/lib/mediawiki.ApiRequest.js
@@ -10,8 +10,6 @@ var Agent = require('./_http_agent.js').Agent,
 	});
 require('http').globalAgent = httpAgent;
 
-var parsoidConfig = require('./mediawiki.ParsoidConfig');
-
 var request = require('request'),
 	qs = require('querystring'),
 	events = require('events'),
@@ -23,7 +21,7 @@ var request = require('request'),
 var PARSOID_RVPROP = ('content|ids|timestamp|user|userid|size|sha1|contentmodel|comment');
 
 // Wikia change - set proper user agent for metric processor Parsoids
-var userAgent = parsoidConfig.userAgent ? parsoidConfig.userAgent : 'Parsoid/0.1';
+var userAgent = process.env.USER_AGENT ? process.env.USER_AGENT : 'Parsoid/0.1';
 
 /**
  * @class


### PR DESCRIPTION
Allow to differentiate between requests generated by regular VE traffic vs requests resulting from background jobs processing.