### PR TITLE
parsoid: don't call MW API via icache

### DIFF
--- a/api/localsettings.js
+++ b/api/localsettings.js
@@ -11,7 +11,7 @@ exports.setup = function( parsoidConfig ) {
 		if ( envName !== '' && envName !== 'dev' ) {
 			parsoidConfig.parsoidCacheURI = `http://${envName}.parsoid-cache/`;
 			parsoidConfig.parsoidCacheProxy = `http://${envName}.icache.service.consul:80/`;
-			parsoidConfig.defaultAPIProxyURI = `http://${envName}.icache.service.consul:80/`;
+			parsoidConfig.defaultAPIProxyURI = 'http://mediawiki-prod:80/';
 		} else {
 			// PLATFORM-3727: make sure not to send API calls through Fastly in dev as well
 			parsoidConfig.defaultAPIProxyURI = 'http://border.service.consul:80/';

--- a/tests/mocha/localSettings.js
+++ b/tests/mocha/localSettings.js
@@ -37,17 +37,14 @@ describe('Dynamic local settings', function () {
 		});
 	});
 
-	var nonDevTestCases = [ 'prod', 'staging' ];
-	nonDevTestCases.forEach(function (envName) {
-		it(`defines cache properties if env = ${envName}`, function () {
-			process.env.ENV = envName;
+	it('defines cache properties if env = prod', function () {
+		process.env.ENV = 'prod';
 
-			setup(parsoidConfig);
+		setup(parsoidConfig);
 
-			parsoidConfig.should.have.property('parsoidCacheURI', `http://${envName}.parsoid-cache/`);
-			parsoidConfig.should.have.property('parsoidCacheProxy', `http://${envName}.icache.service.consul:80/`);
-			parsoidConfig.should.have.property('defaultAPIProxyURI', `http://${envName}.icache.service.consul:80/`);
-		});
+		parsoidConfig.should.have.property('parsoidCacheURI', 'http://prod.parsoid-cache/');
+		parsoidConfig.should.have.property('parsoidCacheProxy', 'http://prod.icache.service.consul:80/');
+		parsoidConfig.should.have.property('defaultAPIProxyURI', 'http://mediawiki-prod:80/');
 	});
 
 	after(function () {


### PR DESCRIPTION
Make parsoid call MW API directly, rather than using icache as a proxy. Keep icache as a proxy for parsoid->parsoid calls for now.