### PR TITLE
Revert "Merge pull request #42 from Wikia/dont-call-mw-via-icache"

### DIFF
--- a/api/localsettings.js
+++ b/api/localsettings.js
@@ -11,7 +11,7 @@ exports.setup = function( parsoidConfig ) {
 		if ( envName !== '' && envName !== 'dev' ) {
 			parsoidConfig.parsoidCacheURI = `http://${envName}.parsoid-cache/`;
 			parsoidConfig.parsoidCacheProxy = `http://${envName}.icache.service.consul:80/`;
-			parsoidConfig.defaultAPIProxyURI = 'http://mediawiki-prod:80/';
+			parsoidConfig.defaultAPIProxyURI = `http://${envName}.icache.service.consul:80/`;
 		} else {
 			// PLATFORM-3727: make sure not to send API calls through Fastly in dev as well
 			parsoidConfig.defaultAPIProxyURI = 'http://border.service.consul:80/';

--- a/tests/mocha/localSettings.js
+++ b/tests/mocha/localSettings.js
@@ -37,14 +37,17 @@ describe('Dynamic local settings', function () {
 		});
 	});
 
-	it('defines cache properties if env = prod', function () {
-		process.env.ENV = 'prod';
+	var nonDevTestCases = [ 'prod', 'staging' ];
+	nonDevTestCases.forEach(function (envName) {
+		it(`defines cache properties if env = ${envName}`, function () {
+			process.env.ENV = envName;
 
-		setup(parsoidConfig);
+			setup(parsoidConfig);
 
-		parsoidConfig.should.have.property('parsoidCacheURI', 'http://prod.parsoid-cache/');
-		parsoidConfig.should.have.property('parsoidCacheProxy', 'http://prod.icache.service.consul:80/');
-		parsoidConfig.should.have.property('defaultAPIProxyURI', 'http://mediawiki-prod:80/');
+			parsoidConfig.should.have.property('parsoidCacheURI', `http://${envName}.parsoid-cache/`);
+			parsoidConfig.should.have.property('parsoidCacheProxy', `http://${envName}.icache.service.consul:80/`);
+			parsoidConfig.should.have.property('defaultAPIProxyURI', `http://${envName}.icache.service.consul:80/`);
+		});
 	});
 
 	after(function () {


### PR DESCRIPTION
Bypassing icache for parsoid -> MW calls caused issues with our staging envs setup. Let's revert this change for now and think how to handle those.

This reverts commit ce694b4460e90d31ad2159cf32026c4648e23ad1, reversing
changes made to d02a918ffc56f3745024c9b051ca14cae2b4360e.