### PR TITLE
Stop using icache

### DIFF
--- a/api/localsettings.js
+++ b/api/localsettings.js
@@ -9,9 +9,7 @@ exports.setup = function( parsoidConfig ) {
 		const envName = (process.env.ENV + '').toLowerCase();
 
 		if ( envName !== '' && envName !== 'dev' ) {
-			parsoidConfig.parsoidCacheURI = `http://${envName}.parsoid-cache/`;
-			parsoidConfig.parsoidCacheProxy = `http://${envName}.icache.service.consul:80/`;
-			parsoidConfig.defaultAPIProxyURI = `http://${envName}.icache.service.consul:80/`;
+			parsoidConfig.defaultAPIProxyURI = 'http://mediawiki-prod:80/';
 		} else {
 			// PLATFORM-3727: make sure not to send API calls through Fastly in dev as well
 			parsoidConfig.defaultAPIProxyURI = 'http://border.service.consul:80/';

--- a/api/routes.js
+++ b/api/routes.js
@@ -444,7 +444,10 @@ var wt2html = function( req, res, wt ) {
 
 routes.interParams = function( req, res, next ) {
 	if ( req.params[0].match(/https?:\/\//) ) {
-		parsoidConfig.setInterwiki( req.params[0], req.params[0] );
+		// Route requests from staging environments to the appropriate MediaWiki deployment
+		const envMatch = /^.*\.(verify|preview|sandbox[^\.]*)\.(fandom\.com|wikia\.(com|org))/.exec(req.params[0]);
+		const envSpecificProxy = envMatch ? `http://mediawiki-${envMatch[1]}:80` : undefined;
+		parsoidConfig.setInterwiki( req.params[0], req.params[0], envSpecificProxy );
 		res.locals.iwp = req.params[0] ;
 	} else {
 		res.locals.iwp = req.params[0] || parsoidConfig.defaultWiki || '';

--- a/tests/mocha/localSettings.js
+++ b/tests/mocha/localSettings.js
@@ -19,35 +19,28 @@ describe('Dynamic local settings', function () {
 
 		setup(parsoidConfig);
 
-		parsoidConfig.should.not.have.property('parsoidCacheURI');
-		parsoidConfig.should.not.have.property('parsoidCacheProxy');
 		parsoidConfig.should.not.have.property('defaultAPIProxyURI');
 	});
 
 
 	var devTestCases = [ 'dev', 'DEV', 'dEV' ];
 	devTestCases.forEach(function (envName) {
-		it(`does not define cache properties if env = ${envName}`, function () {
+		it(`defines cache property if env = ${envName}`, function () {
 			process.env.ENV = envName;
 
 			setup(parsoidConfig);
 
-			parsoidConfig.should.not.have.property('parsoidCacheURI');
-			parsoidConfig.should.not.have.property('parsoidCacheProxy');
+			parsoidConfig.should.have.property('defaultAPIProxyURI', 'http://border.service.consul:80/');
 		});
 	});
 
-	var nonDevTestCases = [ 'prod', 'staging' ];
-	nonDevTestCases.forEach(function (envName) {
-		it(`defines cache properties if env = ${envName}`, function () {
-			process.env.ENV = envName;
 
-			setup(parsoidConfig);
+	it('defines cache property if env = prod', function () {
+		process.env.ENV = 'prod';
 
-			parsoidConfig.should.have.property('parsoidCacheURI', `http://${envName}.parsoid-cache/`);
-			parsoidConfig.should.have.property('parsoidCacheProxy', `http://${envName}.icache.service.consul:80/`);
-			parsoidConfig.should.have.property('defaultAPIProxyURI', `http://${envName}.icache.service.consul:80/`);
-		});
+		setup(parsoidConfig);
+
+		parsoidConfig.should.have.property('defaultAPIProxyURI', 'http://mediawiki-prod:80/');
 	});
 
 	after(function () {


### PR DESCRIPTION
Parsoid is still using icache for calling MW and for
optimistically fetching potential cached versions of
previous page revisions. As icache is going away, we
need to migrate Parsoid away from it.

* Disable fetching cached versions via icache,
  as hit ratio is extremely low so there is no value
  in trying to reimplement this elsewhere.
* Call MW API directly by using the MW k8s service name
  as the HTTP proxy. Add support for handling staging
  environment URLs and route those calls via the appropriate
  staging deployment.