### PR TITLE
Use numeric user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:6.14.1-alpine
 
 RUN mkdir -p /usr/wikia/parsoid
 
-RUN adduser -SH -g '' -h /nonexistent parsoid
-RUN chown -R parsoid /usr/wikia/parsoid
-
 RUN apk add --no-cache git python make g++
 
 # cache dependencies in a separate layer from the main app
@@ -14,6 +11,8 @@ RUN npm install --production
 
 COPY . /usr/wikia/parsoid
 
-USER parsoid
+RUN chown -R 65534:65534 /usr/wikia/parsoid
+
+USER 65534
 
 CMD ["node", "api/server.js"]


### PR DESCRIPTION
Use numeric user in the application's Dockerfile to be compatible with stricter k8s security rules.