### PR TITLE
Switch Parsoid to use UCP MW deployment

### DIFF
--- a/api/localsettings.js
+++ b/api/localsettings.js
@@ -9,7 +9,7 @@ exports.setup = function( parsoidConfig ) {
 		const envName = (process.env.ENV + '').toLowerCase();
 
 		if ( envName !== '' && envName !== 'dev' ) {
-			parsoidConfig.defaultAPIProxyURI = 'http://mediawiki-prod:80/';
+			parsoidConfig.defaultAPIProxyURI = 'http://mediawiki-prod-ucp:80/';
 		} else {
 			// PLATFORM-3727: make sure not to send API calls through Fastly in dev as well
 			parsoidConfig.defaultAPIProxyURI = 'http://border.service.consul:80/';


### PR DESCRIPTION
We'd like to switch all traffic to the new multiversion MW deployment and get rid of the old 1.19-exclusive deployment. Let's update Parsoid to call the new deployment.